### PR TITLE
Obey max/min volume more precisely

### DIFF
--- a/Source/MathUtils.cs
+++ b/Source/MathUtils.cs
@@ -29,6 +29,16 @@ namespace KSPAPIExtensions
             return false;
         }
 
+        public static float Ceiling(float value, float precision)
+        {
+            return (float)Math.Ceiling(value / precision) * precision;
+        }
+
+        public static float Floor(float value, float precision)
+        {
+            return (float)Math.Floor(value / precision) * precision;
+        }
+
         /// <summary>
         /// Round value to the nearest. 
         /// </summary>

--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
+using KSPAPIExtensions;
 
 namespace ProceduralParts
 {
@@ -21,6 +22,9 @@ namespace ProceduralParts
 
     public abstract class ProceduralAbstractShape : PartModule
     {
+        internal const float SliderPrecision = 0.001f;
+        internal const float IteratorIncrement = 1048.5f / (1024 * 1024); // a float slightly below sliderprecision
+
         public override void OnAwake()
         {
             base.OnAwake();
@@ -385,6 +389,17 @@ namespace ProceduralParts
             var window = FindObjectsOfType<UIPartActionWindow>().FirstOrDefault(w => w.part == part);
             if (window != null)
                 window.displayDirty = true;
+        }
+
+        protected float TruncateForSlider(float value, float incrementDirection)
+        {
+            var truncateFunc = GetTruncateFunc(incrementDirection);
+            return truncateFunc.Invoke(value, SliderPrecision);
+        }
+
+        protected Func<float, float, float> GetTruncateFunc(float incrementDirection)
+        {
+            return incrementDirection < 0 ? (Func<float, float, float>)MathUtils.Floor : MathUtils.Ceiling;
         }
     }
 }

--- a/Source/ProceduralAbstractSoRShape.cs
+++ b/Source/ProceduralAbstractSoRShape.cs
@@ -13,6 +13,7 @@ namespace ProceduralParts
         internal const int MinCircleVertexes = 12;
         internal const float MaxCircleError = 0.01f;
         internal const float MaxDiameterChange = 5.0f;
+        internal const float SliderPrecision = 0.001f;
 
         [KSPField]
         public string topNodeName = "top";
@@ -1269,5 +1270,15 @@ namespace ProceduralParts
         }
         #endregion
 
+        protected float TruncateForSlider(float value, float incrementDirection)
+        {
+            var truncateFunc = GetTruncateFunc(incrementDirection);
+            return truncateFunc.Invoke(value, SliderPrecision);
+        }
+
+        protected Func<float, float, float> GetTruncateFunc(float incrementDirection)
+        {
+            return incrementDirection < 0 ? (Func<float, float, float>)MathUtils.Floor : MathUtils.Ceiling;
+        }
     }
 }

--- a/Source/ProceduralAbstractSoRShape.cs
+++ b/Source/ProceduralAbstractSoRShape.cs
@@ -13,7 +13,6 @@ namespace ProceduralParts
         internal const int MinCircleVertexes = 12;
         internal const float MaxCircleError = 0.01f;
         internal const float MaxDiameterChange = 5.0f;
-        internal const float SliderPrecision = 0.001f;
 
         [KSPField]
         public string topNodeName = "top";
@@ -1269,16 +1268,5 @@ namespace ProceduralParts
 
         }
         #endregion
-
-        protected float TruncateForSlider(float value, float incrementDirection)
-        {
-            var truncateFunc = GetTruncateFunc(incrementDirection);
-            return truncateFunc.Invoke(value, SliderPrecision);
-        }
-
-        protected Func<float, float, float> GetTruncateFunc(float incrementDirection)
-        {
-            return incrementDirection < 0 ? (Func<float, float, float>)MathUtils.Floor : MathUtils.Ceiling;
-        }
     }
 }

--- a/Source/ProceduralShapeBezierCone.cs
+++ b/Source/ProceduralShapeBezierCone.cs
@@ -121,12 +121,12 @@ namespace ProceduralParts
             if (volume < PPart.volumeMin)
             {
                 clampedVolume = PPart.volumeMin;
-                inc = 0.001f;
+                inc = IteratorIncrement;
             }
             else if (volume > PPart.volumeMax)
             {
                 clampedVolume = PPart.volumeMax;
-                inc = -0.001f;
+                inc = -IteratorIncrement;
             }
 
             if (inc != 0)

--- a/Source/ProceduralShapeBezierCone.cs
+++ b/Source/ProceduralShapeBezierCone.cs
@@ -137,6 +137,7 @@ namespace ProceduralParts
             {
                 // The volume is directly proportional to the length
                 length *= Volume / vol;
+                length = TruncateForSlider(length, inc);
 
                 Volume = CalcVolume();
             }
@@ -153,19 +154,14 @@ namespace ProceduralParts
 
         private void IterateLimitVolume(ref float toTweak, float vol, float inc)
         {
-            float oToTweak = toTweak;
-            float lVol;
-            float lToTweak;
-            int count = 1;
-            do
+            var oldToTweak = toTweak;
+            var i = 1;
+            while (vol < PPart.volumeMin && inc > 0 || vol > PPart.volumeMax && inc < 0)
             {
-                lVol = vol;
-                lToTweak = toTweak;
-                toTweak = oToTweak + count++ * inc;
+                toTweak = TruncateForSlider(oldToTweak + i * inc, inc);
                 vol = CalcVolume();
+                i++;
             }
-            while (Mathf.Abs(vol - Volume) < Mathf.Abs(lVol - Volume));
-            toTweak = lToTweak;
         }
 
         private float CalcVolume()

--- a/Source/ProceduralShapeBezierCone.cs
+++ b/Source/ProceduralShapeBezierCone.cs
@@ -142,19 +142,19 @@ namespace ProceduralParts
         private void ClampToLimits(float volume, float clampedVolume, float inc)
         {
             // ReSharper disable CompareOfFloatsByEqualityOperator
-            if (length != oldLength || oldSelectedShape != selectedShape)
-            {
-                // The volume is directly proportional to the length
-                length *= clampedVolume / volume;
-                length = TruncateForSlider(length, inc);
-            }
-            else if (bottomDiameter != oldBottomDiameter)
+            if (bottomDiameter != oldBottomDiameter)
             {
                 IterateLimitVolume(ref bottomDiameter, volume, inc);
             }
             else if (topDiameter != oldTopDiameter)
             {
                 IterateLimitVolume(ref topDiameter, volume, inc);
+            }
+            else
+            {
+                // The volume is directly proportional to the length
+                length *= clampedVolume / volume;
+                length = TruncateForSlider(length, inc);
             }
         }
 

--- a/Source/ProceduralShapeCone.cs
+++ b/Source/ProceduralShapeCone.cs
@@ -191,11 +191,7 @@ namespace ProceduralParts
                     refreshRequired = true;
                     var excessVol = oldVolume - volume;
 
-                    if (oldLength != length)
-                    {
-                        length = TruncateForSlider(volume * 12f / (Mathf.PI * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)), -excessVol);
-                    }
-                    else if (oldBottomDiameter != bottomDiameter)
+                    if (oldBottomDiameter != bottomDiameter)
                     {
                         // this becomes solving the quadratic on bottomDiameter
                         float a = length * Mathf.PI;
@@ -205,7 +201,7 @@ namespace ProceduralParts
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
                         bottomDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
                     }
-                    else
+                    else if (oldTopDiameter != topDiameter)
                     {
                         // this becomes solving the quadratic on topDiameter
                         float a = length * Mathf.PI;
@@ -214,6 +210,10 @@ namespace ProceduralParts
 
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
                         topDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
+                    }
+                    else
+                    {
+                        length = TruncateForSlider(volume * 12f / (Mathf.PI * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)), -excessVol);
                     }
                     volume = CalculateVolume();
                 }

--- a/Source/ProceduralShapeCone.cs
+++ b/Source/ProceduralShapeCone.cs
@@ -176,21 +176,26 @@ namespace ProceduralParts
             if (!force && oldTopDiameter == topDiameter && oldBottomDiameter == bottomDiameter && oldLength == length)
                 return;
 
+            var refreshRequired = false;
+
             // Maxmin the volume.
             if (HighLogic.LoadedSceneIsEditor)
             {
                 MaintainParameterRelations();
 
-                float volume = (Mathf.PI * length * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)) / 12f;
+                var volume = CalculateVolume();
                 var oldVolume = volume;
 
                 if (MathUtils.TestClamp(ref volume, PPart.volumeMin, PPart.volumeMax))
                 {
+                    refreshRequired = true;
                     var excessVol = oldVolume - volume;
 
                     if (oldLength != length)
+                    {
                         length = TruncateForSlider(volume * 12f / (Mathf.PI * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)), -excessVol);
-                    else if(oldBottomDiameter != bottomDiameter)
+                    }
+                    else if (oldBottomDiameter != bottomDiameter)
                     {
                         // this becomes solving the quadratic on bottomDiameter
                         float a = length * Mathf.PI;
@@ -200,7 +205,7 @@ namespace ProceduralParts
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
                         bottomDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
                     }
-                    else 
+                    else
                     {
                         // this becomes solving the quadratic on topDiameter
                         float a = length * Mathf.PI;
@@ -210,12 +215,13 @@ namespace ProceduralParts
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
                         topDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
                     }
+                    volume = CalculateVolume();
                 }
                 Volume = volume;
             }
             else
             {
-                Volume = (Mathf.PI * length * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)) / 12f;
+                Volume = CalculateVolume();
             }
 
             // Perpendicular.
@@ -231,8 +237,16 @@ namespace ProceduralParts
             oldBottomDiameter = bottomDiameter;
             oldLength = length;
             // ReSharper restore CompareOfFloatsByEqualityOperator
-            //RefreshPartEditorWindow();
+            if (refreshRequired)
+            {
+                RefreshPartEditorWindow();
+            }
             UpdateInterops();
+        }
+
+        private float CalculateVolume()
+        {
+            return (Mathf.PI * length * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)) / 12f;
         }
         #endregion
 

--- a/Source/ProceduralShapeCone.cs
+++ b/Source/ProceduralShapeCone.cs
@@ -10,17 +10,17 @@ namespace ProceduralParts
         #region Config parameters
 
         [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = false, guiName = "Top", guiFormat = "F3", guiUnits="m"),
-		 UI_FloatEdit(scene = UI_Scene.Editor, minValue = 0.25f, incrementLarge = 1.25f, incrementSmall = 0.25f, incrementSlide = 0.001f, sigFigs = 5, unit="m", useSI = true)]
+		 UI_FloatEdit(scene = UI_Scene.Editor, minValue = 0.25f, incrementLarge = 1.25f, incrementSmall = 0.25f, incrementSlide = SliderPrecision, sigFigs = 5, unit="m", useSI = true)]
         public float topDiameter = 1.25f;
         protected float oldTopDiameter;
 
         [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = false, guiName = "Bottom", guiFormat = "F3", guiUnits = "m"),
-		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = 0.001f, sigFigs = 5, unit="m", useSI = true)]
+		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = SliderPrecision, sigFigs = 5, unit="m", useSI = true)]
         public float bottomDiameter = 1.25f;
         protected float oldBottomDiameter;
 
         [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = false, guiName = "Length", guiFormat = "F3", guiUnits = "m"),
-		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = 0.001f, sigFigs = 5, unit="m", useSI = true)]
+		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = SliderPrecision, sigFigs = 5, unit="m", useSI = true)]
         public float length = 1f;
         protected float oldLength;
 
@@ -182,11 +182,14 @@ namespace ProceduralParts
                 MaintainParameterRelations();
 
                 float volume = (Mathf.PI * length * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)) / 12f;
+                var oldVolume = volume;
 
                 if (MathUtils.TestClamp(ref volume, PPart.volumeMin, PPart.volumeMax))
                 {
+                    var excessVol = oldVolume - volume;
+
                     if (oldLength != length)
-                        length = volume * 12f / (Mathf.PI * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter));
+                        length = TruncateForSlider(volume * 12f / (Mathf.PI * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)), -excessVol);
                     else if(oldBottomDiameter != bottomDiameter)
                     {
                         // this becomes solving the quadratic on bottomDiameter
@@ -195,7 +198,7 @@ namespace ProceduralParts
                         float c = length * Mathf.PI * topDiameter * topDiameter - volume * 12f;
 
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
-                        bottomDiameter = (det - b) / (2f * a);
+                        bottomDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
                     }
                     else 
                     {
@@ -205,7 +208,7 @@ namespace ProceduralParts
                         float c = length * Mathf.PI * bottomDiameter * bottomDiameter - volume * 12f;
 
                         float det = Mathf.Sqrt(b * b - 4 * a * c);
-                        topDiameter = (det - b) / (2f * a);
+                        topDiameter = TruncateForSlider((det - b) / (2f * a), -excessVol);
                     }
                 }
                 Volume = volume;

--- a/Source/ProceduralShapeCylinder.cs
+++ b/Source/ProceduralShapeCylinder.cs
@@ -28,32 +28,38 @@ namespace ProceduralParts
             // ReSharper disable CompareOfFloatsByEqualityOperator
             if (!force && oldDiameter == diameter && oldLength == length)
                 return;
-
-            Volume = diameter * diameter * 0.25f * Mathf.PI * length;
-            var oldVolume = Volume;
+            var volume = CalculateVolume();
+            var oldVolume = volume;
+            var refreshRequired = false;
 
             if (HighLogic.LoadedSceneIsEditor)
             {
                 // Maxmin the volume.
-                if (Volume > PPart.volumeMax)
+                if (volume > PPart.volumeMax)
                 {
-                    Volume = PPart.volumeMax;
+                    volume = PPart.volumeMax;
                 }
-                else if (Volume < PPart.volumeMin)
+                else if (volume < PPart.volumeMin)
                 {
-                    Volume = PPart.volumeMin;
+                    volume = PPart.volumeMin;
                 }
                 else
                     goto nochange;
 
-                var excessVol = oldVolume - Volume;
+                refreshRequired = true;
+                var excessVol = oldVolume - volume;
                 if (oldDiameter != diameter)
-                    diameter = TruncateForSlider(Mathf.Sqrt(Volume / (0.25f * Mathf.PI * length)), -excessVol);
+                {
+                    diameter = TruncateForSlider(Mathf.Sqrt(volume / (0.25f * Mathf.PI * length)), -excessVol);
+                }
                 else
-                    length = TruncateForSlider(Volume / (diameter * diameter * 0.25f * Mathf.PI), -excessVol);
+                {
+                    length = TruncateForSlider(volume / (diameter * diameter * 0.25f * Mathf.PI), -excessVol);
+                }
+                volume = CalculateVolume();
             }
         nochange:
-
+            Volume = volume;
             Vector2 norm = new Vector2(1, 0);
 
             WriteMeshes(
@@ -64,8 +70,16 @@ namespace ProceduralParts
             oldDiameter = diameter;
             oldLength = length;
             // ReSharper restore CompareOfFloatsByEqualityOperator
-            //RefreshPartEditorWindow();
+            if (refreshRequired)
+            {
+                RefreshPartEditorWindow();
+            }
             UpdateInterops();
+        }
+
+        private float CalculateVolume()
+        {
+            return diameter * diameter * 0.25f * Mathf.PI * length;
         }
 
         public override void UpdateTechConstraints()

--- a/Source/ProceduralShapeCylinder.cs
+++ b/Source/ProceduralShapeCylinder.cs
@@ -7,14 +7,13 @@ namespace ProceduralParts
 
     public class ProceduralShapeCylinder : ProceduralAbstractSoRShape
     {
-
         [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = false, guiName = "Diameter", guiFormat = "F3", guiUnits = "m"),
-         UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = 0.001f, sigFigs = 5, unit="m", useSI = true)]
+         UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = SliderPrecision, sigFigs = 5, unit="m", useSI = true)]
         public float diameter = 1.25f;
         private float oldDiameter;
 
         [KSPField(isPersistant = true, guiActiveEditor = true, guiActive = false, guiName = "Length", guiFormat = "F3", guiUnits = "m"),
-		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = 0.001f, sigFigs = 5, unit="m", useSI = true)]
+		 UI_FloatEdit(scene = UI_Scene.Editor, incrementSlide = SliderPrecision, sigFigs = 5, unit="m", useSI = true)]
         public float length = 1f;
         private float oldLength;
 
@@ -31,21 +30,27 @@ namespace ProceduralParts
                 return;
 
             Volume = diameter * diameter * 0.25f * Mathf.PI * length;
+            var oldVolume = Volume;
 
             if (HighLogic.LoadedSceneIsEditor)
             {
                 // Maxmin the volume.
                 if (Volume > PPart.volumeMax)
+                {
                     Volume = PPart.volumeMax;
+                }
                 else if (Volume < PPart.volumeMin)
+                {
                     Volume = PPart.volumeMin;
+                }
                 else
                     goto nochange;
 
+                var excessVol = oldVolume - Volume;
                 if (oldDiameter != diameter)
-                    diameter = Mathf.Sqrt(Volume / (0.25f * Mathf.PI * length));
+                    diameter = TruncateForSlider(Mathf.Sqrt(Volume / (0.25f * Mathf.PI * length)), -excessVol);
                 else
-                    length = Volume / (diameter * diameter * 0.25f * Mathf.PI);
+                    length = TruncateForSlider(Volume / (diameter * diameter * 0.25f * Mathf.PI), -excessVol);
             }
         nochange:
 

--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -38,10 +38,10 @@ namespace ProceduralParts
         private static readonly Func<float, float> sqrt = Mathf.Sqrt;
         private static readonly Func<float, float, float> pow = Mathf.Pow;
 
-        protected override void UpdateShape(bool force)
+        protected override void UpdateShape(bool forceUpdate)
         {
             // ReSharper disable CompareOfFloatsByEqualityOperator
-            if (!force && oldDiameter == diameter && oldLength == length && oldFillet == fillet)
+            if (!forceUpdate && oldDiameter == diameter && oldLength == length && oldFillet == fillet)
                 return;
 
             var refreshRequired = false;
@@ -144,11 +144,11 @@ namespace ProceduralParts
 
                     if (volume < PPart.volumeMin)
                     {
-                        inc = -0.001f;
+                        inc = -IteratorIncrement;
                     }
                     else if (volume > PPart.volumeMax)
                     {
-                        inc = 0.001f;
+                        inc = IteratorIncrement;
                     }
 
                     if (inc != 0)

--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -55,33 +55,7 @@ namespace ProceduralParts
                 if (filletEdit == null)
                     filletEdit = (UI_FloatEdit)Fields["fillet"].uiControlEditor;
 
-                if (length != oldLength)
-                {
-                    if (length < oldLength && fillet > length)
-                        fillet = length;
-
-                    var volume = CalcVolume();
-                    var clampedVolume = GetClampedVolume(volume);
-                    var excessVol = volume - clampedVolume;
-                    if (excessVol != 0)
-                    {
-                        refreshRequired = true;
-                        // Again using alpha, solve the volume equation below equation for l
-                        // v = 1/24 pi (6 d^2 l+3 (pi-4) d f^2+(10-3 pi) f^3) for l
-                        // l = (-3 (pi-4) pi d f^2+pi (3 pi-10) f^3+24 v)/(6 pi d^2) 
-                        length = (-3f * (Pi - 4f) * Pi * diameter * pow(fillet, 2) + Pi * (3f * Pi - 10f) * pow(fillet, 3) + 24f * clampedVolume) / (6f * Pi * pow(diameter, 2));
-                        length = TruncateForSlider(length, -excessVol);
-                        volume = CalcVolume();
-
-                        // We could iterate here with the fillet and push it back up if it's been pushed down
-                        // but it's altogether too much bother. User will just have to suck it up and not be
-                        // so darn agressive with short lengths. I mean, seriously... :)
-                    }
-
-                    filletEdit.maxValue = Mathf.Min(length, useEndDiameter ? PPart.diameterMax : diameter);
-                    Volume = volume;
-                }
-                else if (diameter != oldDiameter)
+                if (diameter != oldDiameter)
                 {
                     if (useEndDiameter)
                     {
@@ -163,6 +137,32 @@ namespace ProceduralParts
                             i++;
                         }
                     }
+                    Volume = volume;
+                }
+                else if(length != oldLength || forceUpdate)
+                {
+                    if (length < oldLength && fillet > length)
+                        fillet = length;
+
+                    var volume = CalcVolume();
+                    var clampedVolume = GetClampedVolume(volume);
+                    var excessVol = volume - clampedVolume;
+                    if (excessVol != 0)
+                    {
+                        refreshRequired = true;
+                        // Again using alpha, solve the volume equation below equation for l
+                        // v = 1/24 pi (6 d^2 l+3 (pi-4) d f^2+(10-3 pi) f^3) for l
+                        // l = (-3 (pi-4) pi d f^2+pi (3 pi-10) f^3+24 v)/(6 pi d^2) 
+                        length = (-3f * (Pi - 4f) * Pi * diameter * pow(fillet, 2) + Pi * (3f * Pi - 10f) * pow(fillet, 3) + 24f * clampedVolume) / (6f * Pi * pow(diameter, 2));
+                        length = TruncateForSlider(length, -excessVol);
+                        volume = CalcVolume();
+
+                        // We could iterate here with the fillet and push it back up if it's been pushed down
+                        // but it's altogether too much bother. User will just have to suck it up and not be
+                        // so darn agressive with short lengths. I mean, seriously... :)
+                    }
+
+                    filletEdit.maxValue = Mathf.Min(length, useEndDiameter ? PPart.diameterMax : diameter);
                     Volume = volume;
                 }
             }

--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -128,11 +128,11 @@ namespace ProceduralParts
                     if (inc != 0)
                     {
                         refreshRequired = true;
-                        var oldFillet = fillet;
+                        var tempFillet = fillet;
                         var i = 1;
                         while (volume < PPart.volumeMin && inc < 0 || volume > PPart.volumeMax && inc > 0)
                         {
-                            fillet = TruncateForSlider(oldFillet + i * inc, inc);
+                            fillet = TruncateForSlider(tempFillet + i * inc, inc);
                             volume = CalcVolume();
                             i++;
                         }


### PR DESCRIPTION
These changes fix procedural avionics locking up because proc parts return a volume below the minimum volume requested by procedural avionics.